### PR TITLE
Added working base functionality. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+__pycache__/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # youtube-word-frequency
+
+Given a YouTube video URL, this script returns the top n words spoken in the video.
+
+Ex.
+```
+$ cd ~/youtube-word-frequency
+$ python3 main.py
+
+Enter the video link: https://www.youtube.com/watch?v=byTxzzztRBU
+I want the to see the n most common words: 4
+------------------------------------------------
+1. | the  | 117
+2. |  to  | 110
+3. | that | 84
+4. |  of  | 83
+```
+
+## Why?
+
+This can be used to understand your or someone else's most common words. And you can see how many times you said "um"
+
+This can also be used to compare one aspect of your speech patterns, to those of others; that aspect being word frequency.
+
+For example, you want to see how many times Park Jimin says the word "love you army" in a video.
+Then, you can run the script on a video of your own speech, scroll down enough, and compare!
+
+---
+### Details
+Of course, frequency is relative to the length of the video. A short video of one person will likely have less "{some_word}"s than a longer video.
+
+A requirement being that the video has captions. Youtube usually autogenerates captions for videos, but you have to give it sufficient time after an upload.
+
+---
+
+## Todo:
+
+
+* Provide Support for playlists and a series of youtube videos.
+
+* Create a GUI to improve the user experience.
+
+## Unattended Error Todos:
+
+* Error Handling for invalid video id
+
+* Error Handling for videos without English Subtitles
+
+* Error Handling for videos with no captions
+
+* Support https://youtu.be/byTxzzztRBU style shortened links (youtu.be)

--- a/analyzer.py
+++ b/analyzer.py
@@ -1,0 +1,52 @@
+from youtube_transcript_api import YouTubeTranscriptApi
+from collections import Counter
+
+
+def run():
+    '''Recieves Input, Makes API Call, and Outputs Results'''
+    video_link = input('Enter the video link: ')
+
+    if video_link.startswith('https://www.youtube.com/watch?v='):
+
+        n_most_common = input('I want the to see the n most common words: ')
+        video_id = video_link.split('=')[1]
+        transcript = YouTubeTranscriptApi.get_transcript(video_id)
+
+        counter = parse(transcript)
+        print("------------------------------------------------")
+        output(counter, int(n_most_common))
+
+    else:
+        # Using ansi escape codes to output color. https://www.youtube.com/watch?v=W0mlGkew6K4
+        print(
+            'Invalid link, must be in format \033[31mhttps://www.youtube.com/watch?v=\033[0m\033[95mvideo_id\033[0m')
+
+
+def parse(transcript: list[dict['text': str, 'start': float, 'end': float]]):
+    '''Parse into a counter object, counting the frequency of each word'''
+    counter = Counter()
+    for dictionary in transcript:
+        word_list = dictionary['text'].split()
+
+        # Remove Punctuation from each word, to avoid "infrastructure" and "infrastructure," from being counted as seperate words
+        word_list = [word.strip(',.?!') for word in word_list]
+        counter.update(word_list)
+
+    return counter
+
+
+def output(counter: Counter, n_most_common: int):
+    '''
+    Descending output in format:
+    1. | the | 288
+    2. | to  | 255
+    3. | of  | 198
+    4. | is  | 161
+    '''
+    most_common_n = counter.most_common(n_most_common)
+    longest_word_length = max(len(word) for word, _ in most_common_n)
+
+    num_len = len(str(n_most_common))
+    for i, (word, frequency) in enumerate(most_common_n):
+        print("{num:<{num_len}} | {word:^{padding}} | {frequency:>2}".format(
+            num=str(i+1)+'.', word=word, frequency=frequency, padding=longest_word_length, num_len=num_len))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,5 @@
+from analyzer import run
+
+# Run the program
+if __name__ == '__main__':
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+autopep8==1.6.0
+certifi==2021.10.8
+charset-normalizer==2.0.10
+idna==3.3
+pycodestyle==2.8.0
+requests==2.27.1
+toml==0.10.2
+urllib3==1.26.8
+youtube-transcript-api==0.4.3


### PR DESCRIPTION
Mostly described in the README

When running, will prompt for a YouTube video link, and for how many n most common words you want to see.
If the YT link is in the wrong format, will print an error message.

Otherwise, if all is good, will make an API call in analyzer.run(),
			parses the video transcript in analyzer.parse(),
			and prints it in analyzer.output()

YT links can come in multiple formats, but this only supports one, so far.

Made a requirements.txt and a .gitignore
main.py runs analyzer.run()

![image](https://user-images.githubusercontent.com/55062649/151649741-4760b8da-0d6e-4946-8e69-9ec6920b46ef.png)
